### PR TITLE
feat: support openCL for linux IOT 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ########################################
 ## Android layer (Ubuntu 24.04)
 ########################################
-FROM ubuntu:24.04 AS base-android
+FROM docker-registry.qualcomm.com/library/ubuntu:24.04 AS base-android
 
 COPY scripts/image-cleanup /bin
 
@@ -73,7 +73,7 @@ COPY --from=arm64-android-build /opt /opt
 ########################################
 ## Debian layer (Debian trixie)
 ########################################
-FROM debian:trixie AS base-debian
+FROM docker-registry.qualcomm.com/library/debian:trixie AS base-debian
 
 COPY scripts/image-cleanup /bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,8 @@ FROM base AS arm64-linux
 COPY --from=arm64-debian-build /opt /opt
 COPY --from=arm64-debian-build /usr/aarch64-linux-gnu/include/CL /usr/aarch64-linux-gnu/include/CL
 COPY --from=arm64-debian-build /usr/aarch64-linux-gnu/lib/libOpenCL.so /usr/aarch64-linux-gnu/lib/libOpenCL.so
+# setting the OPENCL_SDK_ROOT env var so CMake can find them
+ENV OPENCL_SDK_ROOT="/usr/aarch64-linux-gnu"
 
 # Install clang/llvm tools & libs
 RUN apt-get update && apt-get install -y -q --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ FROM debian:trixie AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ENV ANDROID_NDK_ROOT="/opt/android-ndk-r29"
-
 ENV HEXAGON_SDK_ROOT="/opt/hexagon/6.4.0.2"
 ENV HEXAGON_TOOLS_ROOT="${HEXAGON_SDK_ROOT}/tools/HEXAGON_Tools/19.0.04"
 ENV DEFAULT_HLOS_ARCH="64"
@@ -40,6 +38,8 @@ RUN /bin/fetch-and-untar hexagon-sdk https://github.com/snapdragon-toolchain/hex
 ## Android arm64 build stage with intermediate stuff
 FROM base AS arm64-android-build
 
+ENV ANDROID_NDK_ROOT="/opt/android-ndk-r29"
+
 # Install Android NDK
 RUN /bin/fetch-and-unzip android-ndk https://dl.google.com/android/repository/android-ndk-r29-linux.zip /opt
 
@@ -73,16 +73,37 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     && update-alternatives --install /usr/bin/clang   clang    /usr/bin/clang-21 100 \
                            --slave   /usr/bin/clang++ clang++  /usr/bin/clang++-21
 
+# Install OpenCL SDK (cross-compiled for aarch64-linux)
+ENV OPENCL_REL="2025.07.22"
+ENV OPENCL_URL="https://github.com/KhronosGroup/OpenCL"
+RUN    /bin/fetch-and-untar opencl-headers    ${OPENCL_URL}-Headers/archive/refs/tags/v${OPENCL_REL}.tar.gz    /tmp/opencl \
+    && /bin/fetch-and-untar opencl-clhpp      ${OPENCL_URL}-CLHPP/archive/refs/tags/v${OPENCL_REL}.tar.gz      /tmp/opencl \
+    && /bin/fetch-and-untar opencl-icd-loader ${OPENCL_URL}-ICD-Loader/archive/refs/tags/v${OPENCL_REL}.tar.gz /tmp/opencl \
+    && cp -r /tmp/opencl/OpenCL-Headers-${OPENCL_REL}/CL         /usr/aarch64-linux-gnu/include    \
+    && cp -r /tmp/opencl/OpenCL-CLHPP-${OPENCL_REL}/include/CL/* /usr/aarch64-linux-gnu/include/CL \
+    && cd /tmp/opencl/OpenCL-ICD-Loader-${OPENCL_REL}     \
+    && cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+    -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+    -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+    -DOPENCL_ICD_LOADER_HEADERS_DIR=/usr/aarch64-linux-gnu/include \
+    && cmake --build build   \
+    && cp build/libOpenCL.so /usr/aarch64-linux-gnu/lib \
+    && rm -rf /tmp/opencl
+
 ### Final stages
 
 ### Final Android arm64 image
 FROM base AS arm64-android
+ENV ANDROID_NDK_ROOT="/opt/android-ndk-r29"
 COPY --from=arm64-android-build /opt /opt
 RUN  /bin/image-cleanup
 
 ### Final Debian arm64 image
 FROM base AS arm64-linux
 COPY --from=arm64-debian-build /opt /opt
+COPY --from=arm64-debian-build /usr/aarch64-linux-gnu/include/CL /usr/aarch64-linux-gnu/include/CL
+COPY --from=arm64-debian-build /usr/aarch64-linux-gnu/lib/libOpenCL.so /usr/aarch64-linux-gnu/lib/libOpenCL.so
 
 # Install clang/llvm tools & libs
 RUN apt-get update && apt-get install -y -q --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,8 @@ RUN    /bin/fetch-and-untar opencl-headers    ${OPENCL_URL}-Headers/archive/refs
     -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
     -DOPENCL_ICD_LOADER_HEADERS_DIR=/usr/aarch64-linux-gnu/include \
     && cmake --build build   \
-    && cp build/libOpenCL.so /usr/aarch64-linux-gnu/lib \
+    && cp build/libOpenCL.so /usr/aarch64-linux-gnu/lib/libOpenCL.so.1 \
+    && ln -s libOpenCL.so.1 /usr/aarch64-linux-gnu/lib/libOpenCL.so \
     && rm -rf /tmp/opencl
 
 ### Final stages
@@ -103,7 +104,8 @@ RUN  /bin/image-cleanup
 FROM base AS arm64-linux
 COPY --from=arm64-debian-build /opt /opt
 COPY --from=arm64-debian-build /usr/aarch64-linux-gnu/include/CL /usr/aarch64-linux-gnu/include/CL
-COPY --from=arm64-debian-build /usr/aarch64-linux-gnu/lib/libOpenCL.so /usr/aarch64-linux-gnu/lib/libOpenCL.so
+COPY --from=arm64-debian-build /usr/aarch64-linux-gnu/lib/libOpenCL.so.1 /usr/aarch64-linux-gnu/lib/libOpenCL.so.1
+RUN ln -s libOpenCL.so.1 /usr/aarch64-linux-gnu/lib/libOpenCL.so
 # setting the OPENCL_SDK_ROOT env var so CMake can find them
 ENV OPENCL_SDK_ROOT="/usr/aarch64-linux-gnu"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,8 @@ COPY scripts/image-cleanup /bin
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ENV ANDROID_NDK_ROOT="/opt/android-ndk-r28b"
+
 ENV HEXAGON_SDK_ROOT="/opt/hexagon/6.4.0.2"
 ENV HEXAGON_TOOLS_ROOT="${HEXAGON_SDK_ROOT}/tools/HEXAGON_Tools/19.0.04"
 ENV DEFAULT_HLOS_ARCH="64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,20 @@ FROM debian:trixie AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ENV HEXAGON_SDK_ROOT="/opt/hexagon/6.4.0.2"
+ARG ANDROID_NDK_VERSION="r29"
+ARG HEXAGON_SDK_VERSION="6.4.0.2"
+ARG OPENCL_REL="2025.07.22"
+ARG LLVM_VERSION="21"
+ENV ANDROID_NDK_VERSION=${ANDROID_NDK_VERSION} \
+    HEXAGON_SDK_VERSION=${HEXAGON_SDK_VERSION} \
+    OPENCL_REL=${OPENCL_REL} \
+    LLVM_VERSION=${LLVM_VERSION}
+
+ENV ANDROID_NDK_ROOT="/opt/android-ndk-${ANDROID_NDK_VERSION}" \
+    HEXAGON_SDK_ROOT="/opt/hexagon/${HEXAGON_SDK_VERSION}"
 ENV HEXAGON_TOOLS_ROOT="${HEXAGON_SDK_ROOT}/tools/HEXAGON_Tools/19.0.04"
+ENV OPENCL_URL="https://github.com/KhronosGroup/OpenCL"
+
 ENV DEFAULT_HLOS_ARCH="64"
 ENV DEFAULT_TOOLS_VARIANT="toolv19"
 ENV DEFAULT_NO_QURT_INC="0"
@@ -31,21 +43,17 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     && /bin/image-cleanup
 
 # Install Hexagon SDK
-RUN /bin/fetch-and-untar hexagon-sdk https://github.com/snapdragon-toolchain/hexagon-sdk/releases/download/v6.4.0.2/hexagon-sdk-v6.4.0.2-amd64-lnx.tar.xz /opt/hexagon
+RUN /bin/fetch-and-untar hexagon-sdk https://github.com/snapdragon-toolchain/hexagon-sdk/releases/download/v${HEXAGON_SDK_VERSION}/hexagon-sdk-v${HEXAGON_SDK_VERSION}-amd64-lnx.tar.xz /opt/hexagon
 
 ### Build stages
 
 ## Android arm64 build stage with intermediate stuff
 FROM base AS arm64-android-build
 
-ENV ANDROID_NDK_ROOT="/opt/android-ndk-r29"
-
 # Install Android NDK
-RUN /bin/fetch-and-unzip android-ndk https://dl.google.com/android/repository/android-ndk-r29-linux.zip /opt
+RUN /bin/fetch-and-unzip android-ndk https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux.zip /opt
 
 # Install OpenCL SDK
-ENV OPENCL_REL="2025.07.22"
-ENV OPENCL_URL="https://github.com/KhronosGroup/OpenCL"
 RUN    /bin/fetch-and-untar opencl-headers    ${OPENCL_URL}-Headers/archive/refs/tags/v${OPENCL_REL}.tar.gz    /tmp/opencl \
     && /bin/fetch-and-untar opencl-clhpp      ${OPENCL_URL}-CLHPP/archive/refs/tags/v${OPENCL_REL}.tar.gz      /tmp/opencl \
     && /bin/fetch-and-untar opencl-icd-loader ${OPENCL_URL}-ICD-Loader/archive/refs/tags/v${OPENCL_REL}.tar.gz /tmp/opencl \
@@ -69,13 +77,11 @@ FROM base AS arm64-debian-build
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
     cross-config crossbuild-essential-arm64 \
     && cd /tmp && wget https://apt.llvm.org/llvm.sh \
-    && chmod +x llvm.sh && ./llvm.sh 21 \
-    && update-alternatives --install /usr/bin/clang   clang    /usr/bin/clang-21 100 \
-                           --slave   /usr/bin/clang++ clang++  /usr/bin/clang++-21
+    && chmod +x llvm.sh && ./llvm.sh ${LLVM_VERSION} \
+    && update-alternatives --install /usr/bin/clang   clang    /usr/bin/clang-${LLVM_VERSION} 100 \
+                           --slave   /usr/bin/clang++ clang++  /usr/bin/clang++-${LLVM_VERSION}
 
 # Install OpenCL SDK (cross-compiled for aarch64-linux)
-ENV OPENCL_REL="2025.07.22"
-ENV OPENCL_URL="https://github.com/KhronosGroup/OpenCL"
 RUN    /bin/fetch-and-untar opencl-headers    ${OPENCL_URL}-Headers/archive/refs/tags/v${OPENCL_REL}.tar.gz    /tmp/opencl \
     && /bin/fetch-and-untar opencl-clhpp      ${OPENCL_URL}-CLHPP/archive/refs/tags/v${OPENCL_REL}.tar.gz      /tmp/opencl \
     && /bin/fetch-and-untar opencl-icd-loader ${OPENCL_URL}-ICD-Loader/archive/refs/tags/v${OPENCL_REL}.tar.gz /tmp/opencl \
@@ -96,7 +102,6 @@ RUN    /bin/fetch-and-untar opencl-headers    ${OPENCL_URL}-Headers/archive/refs
 
 ### Final Android arm64 image
 FROM base AS arm64-android
-ENV ANDROID_NDK_ROOT="/opt/android-ndk-r29"
 COPY --from=arm64-android-build /opt /opt
 RUN  /bin/image-cleanup
 
@@ -113,8 +118,8 @@ ENV OPENCL_SDK_ROOT="/usr/aarch64-linux-gnu"
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
     cross-config crossbuild-essential-arm64 \
     && cd /tmp && wget https://apt.llvm.org/llvm.sh \
-    && chmod +x llvm.sh && ./llvm.sh 21 \
-    && update-alternatives --install /usr/bin/clang   clang    /usr/bin/clang-21 100 \
-                           --slave   /usr/bin/clang++ clang++  /usr/bin/clang++-21 
+    && chmod +x llvm.sh && ./llvm.sh ${LLVM_VERSION} \
+    && update-alternatives --install /usr/bin/clang   clang    /usr/bin/clang-${LLVM_VERSION} 100 \
+                           --slave   /usr/bin/clang++ clang++  /usr/bin/clang++-${LLVM_VERSION}
 
 RUN  /bin/image-cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,6 @@ COPY scripts/image-cleanup /bin
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ENV ANDROID_NDK_ROOT="/opt/android-ndk-r28b"
-
 ENV HEXAGON_SDK_ROOT="/opt/hexagon/6.4.0.2"
 ENV HEXAGON_TOOLS_ROOT="${HEXAGON_SDK_ROOT}/tools/HEXAGON_Tools/19.0.04"
 ENV DEFAULT_HLOS_ARCH="64"
@@ -123,4 +121,9 @@ RUN /bin/fetch-and-untar hexagon-sdk https://github.com/snapdragon-toolchain/hex
 FROM base-debian AS arm64-debian
 
 # Add helper scripts
+COPY --from=arm64-debian-build /opt /opt
+
+# Final arm64 Linux image
+FROM base-debian AS arm64-linux
+
 COPY --from=arm64-debian-build /opt /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 ## Android layer (Ubuntu 24.04)
 ########################################
 FROM docker-registry.qualcomm.com/library/ubuntu:24.04 AS base-android
+LABEL org.opencontainers.image.source="https://github.com/snapdragon-toolchain/docker"
 
 COPY scripts/image-cleanup /bin
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@ This repo contains source code for building Snapdragon toolchain docker images.
 
 Snapdragon toolchain images include various SDKs (Android NDK, Hexagon SDK, etc) 
 required for building libaries and apps for Snapdragon devices.
+
+
+To release a new version of the docker image, please follow the instructions in [release.md](release.md).

--- a/release.md
+++ b/release.md
@@ -1,0 +1,54 @@
+# Release docker image
+
+## Setup
+
+Set these variables before running any release commands:
+
+```bash
+export GITHUB_USER="<your-github-username>"
+export GITHUB_PAT="<your-github-pat>"
+export ANDROID_VERSION="v0.4"           # version tag for arm64-android
+export LINUX_VERSION="v0.1"            # version tag for arm64-linux
+```
+
+## Authenticate to GHCR
+
+```bash
+echo "$GITHUB_PAT" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
+```
+
+## Release Android only
+
+```bash
+cd docker/
+
+./build.sh $ANDROID_VERSION arm64-android
+
+docker push ghcr.io/snapdragon-toolchain/arm64-android:$ANDROID_VERSION
+```
+
+## Release IoT (arm64-linux) only
+
+```bash
+cd docker/
+
+./build.sh $LINUX_VERSION arm64-linux
+
+docker push ghcr.io/snapdragon-toolchain/arm64-linux:$LINUX_VERSION
+```
+
+## Release both Android and IoT
+
+Note: Android and Linux use separate version tags, so they must be built in two separate calls.
+
+```bash
+cd docker/
+
+./build.sh $ANDROID_VERSION arm64-android
+docker push ghcr.io/snapdragon-toolchain/arm64-android:$ANDROID_VERSION
+
+./build.sh $LINUX_VERSION arm64-linux
+docker push ghcr.io/snapdragon-toolchain/arm64-linux:$LINUX_VERSION
+```
+
+Then create releases manually at `https://github.com/snapdragon-toolchain/docker/releases/new`

--- a/release.md
+++ b/release.md
@@ -1,72 +1,44 @@
-# Release docker image
+# Release
 
-## Setup
-
-Set these variables before running any release commands:
+## 1. Setup
 
 ```bash
 export GITHUB_USER="<your-github-username>"
 export GITHUB_PAT="<your-github-pat>"
-export ANDROID_VERSION="v0.4"           # version tag for arm64-android
-export LINUX_VERSION="v0.1"            # version tag for arm64-linux
-export GITHUB_TAG="v0.4-beta"            # version tag for GitHub release
+export GITHUB_TAG="v0.x"
 ```
 
-## Authenticate to GHCR
-Make sure you see **Login Succeeded** after running this command:
+## 2. Authenticate to GHCR
+
+Verify you see **Login Succeeded**:
+
 ```bash
 echo "$GITHUB_PAT" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
 ```
 
-## Release docker image
-### Android only
+## 3. Build and push images
+
+### Android
 
 ```bash
-cd docker/
-
+export ANDROID_VERSION="v0.y"
 ./build.sh $ANDROID_VERSION arm64-android
-
 docker push ghcr.io/snapdragon-toolchain/arm64-android:$ANDROID_VERSION
 ```
 
-### IoT (arm64-linux) only
+### Linux
 
 ```bash
-cd docker/
-
-./build.sh $LINUX_VERSION arm64-linux
-
-docker push ghcr.io/snapdragon-toolchain/arm64-linux:$LINUX_VERSION
-```
-
-### Both Android and IoT
-
-Note: Android and Linux use separate version tags, so they must be built in two separate calls.
-
-```bash
-cd docker/
-
-./build.sh $ANDROID_VERSION arm64-android
-docker push ghcr.io/snapdragon-toolchain/arm64-android:$ANDROID_VERSION
-
+export LINUX_VERSION="v0.z"
 ./build.sh $LINUX_VERSION arm64-linux
 docker push ghcr.io/snapdragon-toolchain/arm64-linux:$LINUX_VERSION
 ```
 
-## Create GitHub release
+## 4. Create GitHub release
 
 ```bash
 git tag -a $GITHUB_TAG -m "Release $GITHUB_TAG"
 git push origin $GITHUB_TAG
 ```
-Then create releases manually at `https://github.com/snapdragon-toolchain/docker/releases/new`
 
-## Remove a previous tag
-
-```bash
-# Delete local tag
-git tag -d <tag-name>
-
-# Delete remote tag
-git push origin --delete <tag-name>
-```
+Then create the release at: https://github.com/snapdragon-toolchain/docker/releases/new

--- a/release.md
+++ b/release.md
@@ -9,15 +9,17 @@ export GITHUB_USER="<your-github-username>"
 export GITHUB_PAT="<your-github-pat>"
 export ANDROID_VERSION="v0.4"           # version tag for arm64-android
 export LINUX_VERSION="v0.1"            # version tag for arm64-linux
+export GITHUB_TAG="v0.4-beta"            # version tag for GitHub release
 ```
 
 ## Authenticate to GHCR
-
+Make sure you see **Login Succeeded** after running this command:
 ```bash
 echo "$GITHUB_PAT" | docker login ghcr.io -u "$GITHUB_USER" --password-stdin
 ```
 
-## Release Android only
+## Release docker image
+### Android only
 
 ```bash
 cd docker/
@@ -27,7 +29,7 @@ cd docker/
 docker push ghcr.io/snapdragon-toolchain/arm64-android:$ANDROID_VERSION
 ```
 
-## Release IoT (arm64-linux) only
+### IoT (arm64-linux) only
 
 ```bash
 cd docker/
@@ -37,7 +39,7 @@ cd docker/
 docker push ghcr.io/snapdragon-toolchain/arm64-linux:$LINUX_VERSION
 ```
 
-## Release both Android and IoT
+### Both Android and IoT
 
 Note: Android and Linux use separate version tags, so they must be built in two separate calls.
 
@@ -51,4 +53,20 @@ docker push ghcr.io/snapdragon-toolchain/arm64-android:$ANDROID_VERSION
 docker push ghcr.io/snapdragon-toolchain/arm64-linux:$LINUX_VERSION
 ```
 
+## Create GitHub release
+
+```bash
+git tag -a $GITHUB_TAG -m "Release $GITHUB_TAG"
+git push origin $GITHUB_TAG
+```
 Then create releases manually at `https://github.com/snapdragon-toolchain/docker/releases/new`
+
+## Remove a previous tag
+
+```bash
+# Delete local tag
+git tag -d <tag-name>
+
+# Delete remote tag
+git push origin --delete <tag-name>
+```


### PR DESCRIPTION
Test:
```
root@qcs9075-iq-9075-evk:/tmp/artifact/llama_cpp_bundle# LD_LIBRARY_PATH=$(pwd)/lib ADSP_LIBRARY_PATH=$(pwd)/lib GGML_HEXAGON_NDEV=0 NO_COLOR=1 \
>   ./bin/llama-completion \
>     --model /tmp/artifact/gguf/model.gguf \
>     --device GPUOpenCL \
>     -fa off \
>     -c 2048 \
>     -n 32 --seed 42 \
>     -p "What is the capital of France?"
```
Result on IQ9 (QCS9075):
```
ggml_opencl: selected platform: 'QUALCOMM Snapdragon(TM)'

ggml_opencl: device: 'QUALCOMM Adreno(TM) 663 (OpenCL 3.0 Adreno(TM) 663)'
ggml_opencl: OpenCL driver: OpenCL 3.0 QUALCOMM build: 0838.3 Compiler E031.50.15.00
ggml_opencl: vector subgroup broadcast support: true
ggml_opencl: device FP16 support: true
ggml_opencl: mem base addr align: 128
ggml_opencl: max mem alloc size: 1024 MB
ggml_opencl: device max image buffer size (pixels): 67108864
ggml_opencl: device max workgroup size: 1024
ggml_opencl: SVM coarse grain buffer support: true
ggml_opencl: SVM fine grain buffer support: true
ggml_opencl: SVM fine grain system support: false
ggml_opencl: SVM atomics support: true
ggml_opencl: flattening quantized weights representation as struct of arrays (GGML_OPENCL_SOA_Q)
ggml_opencl: using kernels optimized for Adreno (GGML_OPENCL_USE_ADRENO_KERNELS)
ggml_opencl: loading OpenCL kernels............................................................................................................
ggml_opencl: default device: 'QUALCOMM Adreno(TM) 663 (OpenCL 3.0 Adreno(TM) 663)'
ggml-hex: Loading driver libcdsprpc.so
ggml-hex: Hexagon backend (experimental) : allocating new registry : ndev 0
ggml-hex: Hexagon Arch version v73
main: llama backend init
main: load the model and apply lora adapter, if any
common_init_result: fitting params to device memory, for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on
llama_params_fit_impl: projected to use 1048 MiB of device memory vs. 35284 MiB of free device memory
llama_params_fit_impl: will leave 34236 >= 1024 MiB of free device memory, no changes needed
llama_params_fit: successfully fit params to free device memory
llama_params_fit: fitting params to free memory took 0.46 seconds
llama_model_load_from_file_impl: using device GPUOpenCL (QUALCOMM Adreno(TM) 663) (unknown id) - 0 MiB free
llama_model_loader: loaded meta data with 35 key-value pairs and 147 tensors from /tmp/artifact/gguf/model.gguf (version GGUF V3 (latest))
llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
llama_model_loader: - kv   0:                       general.architecture str              = llama
llama_model_loader: - kv   1:                               general.type str              = model
llama_model_loader: - kv   2:                               general.name str              = Llama 3.2 1B Instruct
llama_model_loader: - kv   3:                           general.finetune str              = Instruct
llama_model_loader: - kv   4:                           general.basename str              = Llama-3.2
llama_model_loader: - kv   5:                         general.size_label str              = 1B
llama_model_loader: - kv   6:                            general.license str              = llama3.2
llama_model_loader: - kv   7:                               general.tags arr[str,6]       = ["facebook", "meta", "pytorch", "llam...
llama_model_loader: - kv   8:                          general.languages arr[str,8]       = ["en", "de", "fr", "it", "pt", "hi", ...
llama_model_loader: - kv   9:                          llama.block_count u32              = 16
llama_model_loader: - kv  10:                       llama.context_length u32              = 131072
llama_model_loader: - kv  11:                     llama.embedding_length u32              = 2048
llama_model_loader: - kv  12:                  llama.feed_forward_length u32              = 8192
llama_model_loader: - kv  13:                 llama.attention.head_count u32              = 32
llama_model_loader: - kv  14:              llama.attention.head_count_kv u32              = 8
llama_model_loader: - kv  15:                       llama.rope.freq_base f32              = 500000.000000
llama_model_loader: - kv  16:     llama.attention.layer_norm_rms_epsilon f32              = 0.000010
llama_model_loader: - kv  17:                 llama.attention.key_length u32              = 64
llama_model_loader: - kv  18:               llama.attention.value_length u32              = 64
llama_model_loader: - kv  19:                          general.file_type u32              = 2
llama_model_loader: - kv  20:                           llama.vocab_size u32              = 128256
llama_model_loader: - kv  21:                 llama.rope.dimension_count u32              = 64
llama_model_loader: - kv  22:                       tokenizer.ggml.model str              = gpt2
llama_model_loader: - kv  23:                         tokenizer.ggml.pre str              = llama-bpe
llama_model_loader: - kv  24:                      tokenizer.ggml.tokens arr[str,128256]  = ["!", "\"", "#", "$", "%", "&", "'", ...
llama_model_loader: - kv  25:                  tokenizer.ggml.token_type arr[i32,128256]  = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...
llama_model_loader: - kv  26:                      tokenizer.ggml.merges arr[str,280147]  = ["Ġ Ġ", "Ġ ĠĠĠ", "ĠĠ ĠĠ", "...
llama_model_loader: - kv  27:                tokenizer.ggml.bos_token_id u32              = 128000
llama_model_loader: - kv  28:                tokenizer.ggml.eos_token_id u32              = 128009
llama_model_loader: - kv  29:                    tokenizer.chat_template str              = {{- bos_token }}\n{%- if custom_tools ...
llama_model_loader: - kv  30:               general.quantization_version u32              = 2
llama_model_loader: - kv  31:                      quantize.imatrix.file str              = /models_out/Llama-3.2-1B-Instruct-GGU...
llama_model_loader: - kv  32:                   quantize.imatrix.dataset str              = /training_dir/calibration_datav3.txt
llama_model_loader: - kv  33:             quantize.imatrix.entries_count i32              = 112
llama_model_loader: - kv  34:              quantize.imatrix.chunks_count i32              = 125
llama_model_loader: - type  f32:   34 tensors
llama_model_loader: - type q4_0:  110 tensors
llama_model_loader: - type q4_1:    2 tensors
llama_model_loader: - type q6_K:    1 tensors
print_info: file format = GGUF V3 (latest)
print_info: file type   = Q4_0
print_info: file size   = 729.75 MiB (4.95 BPW) 
load: 0 unused tokens
load: printing all EOG tokens:
load:   - 128001 ('<|end_of_text|>')
load:   - 128008 ('<|eom_id|>')
load:   - 128009 ('<|eot_id|>')
load: special tokens cache size = 256
load: token to piece cache size = 0.7999 MB
print_info: arch                  = llama
print_info: vocab_only            = 0
print_info: no_alloc              = 0
print_info: n_ctx_train           = 131072
print_info: n_embd                = 2048
print_info: n_embd_inp            = 2048
print_info: n_layer               = 16
print_info: n_head                = 32
print_info: n_head_kv             = 8
print_info: n_rot                 = 64
print_info: n_swa                 = 0
print_info: is_swa_any            = 0
print_info: n_embd_head_k         = 64
print_info: n_embd_head_v         = 64
print_info: n_gqa                 = 4
print_info: n_embd_k_gqa          = 512
print_info: n_embd_v_gqa          = 512
print_info: f_norm_eps            = 0.0e+00
print_info: f_norm_rms_eps        = 1.0e-05
print_info: f_clamp_kqv           = 0.0e+00
print_info: f_max_alibi_bias      = 0.0e+00
print_info: f_logit_scale         = 0.0e+00
print_info: f_attn_scale          = 0.0e+00
print_info: n_ff                  = 8192
print_info: n_expert              = 0
print_info: n_expert_used         = 0
print_info: n_expert_groups       = 0
print_info: n_group_used          = 0
print_info: causal attn           = 1
print_info: pooling type          = -1
print_info: rope type             = 0
print_info: rope scaling          = linear
print_info: freq_base_train       = 500000.0
print_info: freq_scale_train      = 1
print_info: n_ctx_orig_yarn       = 131072
print_info: rope_yarn_log_mul     = 0.0000
print_info: rope_finetuned        = unknown
print_info: model type            = 1B
print_info: model params          = 1.24 B
print_info: general.name          = Llama 3.2 1B Instruct
print_info: vocab type            = BPE
print_info: n_vocab               = 128256
print_info: n_merges              = 280147
print_info: BOS token             = 128000 '<|begin_of_text|>'
print_info: EOS token             = 128009 '<|eot_id|>'
print_info: EOT token             = 128009 '<|eot_id|>'
print_info: EOM token             = 128008 '<|eom_id|>'
print_info: LF token              = 198 'Ċ'
print_info: EOG token             = 128001 '<|end_of_text|>'
print_info: EOG token             = 128008 '<|eom_id|>'
print_info: EOG token             = 128009 '<|eot_id|>'
print_info: max token length      = 256
load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
load_tensors: offloading output layer to GPU
load_tensors: offloading 15 repeating layers to GPU
load_tensors: offloaded 17/17 layers to GPU
load_tensors:   CPU_Mapped model buffer size =   205.49 MiB
load_tensors:       OpenCL model buffer size =   729.75 MiB
...........................................................
common_init_result: added <|end_of_text|> logit bias = -inf
common_init_result: added <|eom_id|> logit bias = -inf
common_init_result: added <|eot_id|> logit bias = -inf
llama_context: constructing llama_context
llama_context: n_seq_max     = 1
llama_context: n_ctx         = 2048
llama_context: n_ctx_seq     = 2048
llama_context: n_batch       = 2048
llama_context: n_ubatch      = 512
llama_context: causal_attn   = 1
llama_context: flash_attn    = disabled
llama_context: kv_unified    = false
llama_context: freq_base     = 500000.0
llama_context: freq_scale    = 1
llama_context: n_ctx_seq (2048) < n_ctx_train (131072) -- the full capacity of the model will not be utilized
llama_context:        CPU  output buffer size =     0.49 MiB
llama_kv_cache:     OpenCL KV buffer size =    64.00 MiB
llama_kv_cache: size =   64.00 MiB (  2048 cells,  16 layers,  1/1 seqs), K (f16):   32.00 MiB, V (f16):   32.00 MiB
llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 64
llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 64
sched_reserve: reserving ...
sched_reserve: resolving fused Gated Delta Net support:
sched_reserve: fused Gated Delta Net (autoregressive) enabled
sched_reserve: fused Gated Delta Net (chunked) enabled
sched_reserve:     OpenCL compute buffer size =   254.50 MiB
sched_reserve:        CPU compute buffer size =    14.01 MiB
sched_reserve: graph nodes  = 582
sched_reserve: graph splits = 2
sched_reserve: reserve took 38.40 ms, sched copies = 1
common_init_from_params: warming up the model with an empty run - please wait ... (--no-warmup to disable)
main: llama threadpool init, n_threads = 8
main: chat template is available, enabling conversation mode (disable it with -no-cnv)
*** User-specified prompt will pre-start conversation, did you mean to set --system-prompt (-sys) instead?
main: chat template example:
<|start_header_id|>system<|end_header_id|>

You are a helpful assistant<|eot_id|><|start_header_id|>user<|end_header_id|>

Hello<|eot_id|><|start_header_id|>assistant<|end_header_id|>

Hi there<|eot_id|><|start_header_id|>user<|end_header_id|>

How are you?<|eot_id|><|start_header_id|>assistant<|end_header_id|>



system_info: n_threads = 8 (n_threads_batch = 8) / 8 | CPU : NEON = 1 | ARM_FMA = 1 | REPACK = 1 | 

main: interactive mode on.
sampler seed: 42
sampler params: 
        repeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000, presence_penalty = 0.000
        dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = -1
        top_k = 40, top_p = 0.950, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.800
        mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000, adaptive_target = -1.000, adaptive_decay = 0.900
sampler chain: logits -> ?penalties -> ?dry -> ?top-n-sigma -> top-k -> ?typical -> top-p -> min-p -> ?xtc -> temp-ext -> dist 
generate: n_ctx = 2048, n_batch = 2048, n_predict = 32, n_keep = 1

== Running in interactive mode. ==
 - Press Ctrl+C to interject at any time.
 - Press Return to return control to the AI.
 - To return control without starting a new line, end your input with '/'.
 - If you want to submit another line, end your input with '\'.
 - Not using system message. To change it, set a different value via -sys PROMPT

user

What is the capital of France?assistant

The capital of France is Paris.
```